### PR TITLE
Add new log level: Trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-![obligatory xkcd](http://imgs.xkcd.com/comics/standards.png)
+
+This package is a fork of https://github.com/inconshreveable/log15 with some minor modifications including:
+
+ * Support for log level `trace`
+
 
 # log15 [![godoc reference](https://godoc.org/github.com/inconshreveable/log15?status.png)](https://godoc.org/github.com/inconshreveable/log15) [![Build Status](https://travis-ci.org/inconshreveable/log15.svg?branch=master)](https://travis-ci.org/inconshreveable/log15)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This package is a fork of https://github.com/inconshreveable/log15 with some minor modifications including:
 
  * Support for log level `trace`
- * Support for go mods
+ * Support for go mod
 
 
 # log15 [![godoc reference](https://godoc.org/github.com/inconshreveable/log15?status.png)](https://godoc.org/github.com/inconshreveable/log15) [![Build Status](https://travis-ci.org/inconshreveable/log15.svg?branch=master)](https://travis-ci.org/inconshreveable/log15)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 This package is a fork of https://github.com/inconshreveable/log15 with some minor modifications including:
 
  * Support for log level `trace`
+ * Support for go mods
 
 
 # log15 [![godoc reference](https://godoc.org/github.com/inconshreveable/log15?status.png)](https://godoc.org/github.com/inconshreveable/log15) [![Build Status](https://travis-ci.org/inconshreveable/log15.svg?branch=master)](https://travis-ci.org/inconshreveable/log15)

--- a/format.go
+++ b/format.go
@@ -59,6 +59,8 @@ func TerminalFormat() Format {
 			color = 32
 		case LvlDebug:
 			color = 36
+		case LvlTrace:
+			color = 34
 		}
 
 		b := &bytes.Buffer{}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,7 @@
+module github.com/chainsafe/log15
+
+require (
+	github.com/go-stack/stack v1.8.0
+	github.com/mattn/go-colorable v0.1.2
+	github.com/mattn/go-isatty v0.0.8
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
+github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
+github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
+github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
+github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/log15_test.go
+++ b/log15_test.go
@@ -44,7 +44,7 @@ func TestLazy(t *testing.T) {
 	}
 
 	x = 2
-	l.Info("", "x", Lazy{lazy})
+	l.Trace("", "x", Lazy{lazy})
 	if r.Ctx[1] != 2 {
 		t.Fatalf("Lazy function not evaluated, got %v, expected %d", r.Ctx[1], 1)
 	}
@@ -70,7 +70,7 @@ func TestInvalidLazy(t *testing.T) {
 	l.Info("", "x", Lazy{func(x int) int { return x }})
 	validate()
 
-	l.Info("", "x", Lazy{func() {}})
+	l.Trace("", "x", Lazy{func() {}})
 	validate()
 }
 
@@ -123,7 +123,7 @@ func TestJSONMap(t *testing.T) {
 	}
 
 	l, buf := testFormatter(JsonFormat())
-	l.Error("logging structs", "struct", m)
+	l.Trace("logging structs", "struct", m)
 
 	var v map[string]interface{}
 	decoder := json.NewDecoder(buf)
@@ -260,6 +260,11 @@ func TestLvlFilterHandler(t *testing.T) {
 		t.Fatalf("Expected zero record, but got record with msg: %v", r.Msg)
 	}
 
+	l.Trace("trace'd")
+	if r.Msg != "" {
+		t.Fatalf("Got record msg %s expected %s", r.Msg, "")
+	}
+
 	l.Warn("warned")
 	if r.Msg != "warned" {
 		t.Fatalf("Got record msg %s expected %s", r.Msg, "warned")
@@ -269,6 +274,7 @@ func TestLvlFilterHandler(t *testing.T) {
 	if r.Msg != "error'd" {
 		t.Fatalf("Got record msg %s expected %s", r.Msg, "error'd")
 	}
+
 }
 
 func TestNetHandler(t *testing.T) {
@@ -347,16 +353,16 @@ func TestMatchFilterBuiltin(t *testing.T) {
 	t.Parallel()
 
 	l, h, r := testLogger()
-	l.SetHandler(MatchFilterHandler("lvl", LvlError, h))
+	l.SetHandler(MatchFilterHandler("lvl", LvlTrace, h))
 	l.Info("does not pass")
 
 	if r.Msg != "" {
 		t.Fatalf("got info level record that should not have matched")
 	}
 
-	l.Error("error!")
-	if r.Msg != "error!" {
-		t.Fatalf("did not get error level record that should have matched")
+	l.Trace("trace!")
+	if r.Msg != "trace!" {
+		t.Fatalf("did not get trace level record that should have matched")
 	}
 
 	r.Msg = ""

--- a/log15_test.go
+++ b/log15_test.go
@@ -400,13 +400,13 @@ func TestFailoverHandler(t *testing.T) {
 		StreamHandler(w, JsonFormat()),
 		h))
 
-	l.Debug("test ok")
+	l.Trace("test ok")
 	if r.Msg != "" {
 		t.Fatalf("expected no failover")
 	}
 
 	w.fail = true
-	l.Debug("test failover", "x", 1)
+	l.Trace("test failover", "x", 1)
 	if r.Msg != "test failover" {
 		t.Fatalf("expected failover")
 	}

--- a/log15_test.go
+++ b/log15_test.go
@@ -44,6 +44,27 @@ func TestLazy(t *testing.T) {
 	}
 
 	x = 2
+	l.Info("", "x", Lazy{lazy})
+	if r.Ctx[1] != 2 {
+		t.Fatalf("Lazy function not evaluated, got %v, expected %d", r.Ctx[1], 1)
+	}
+}
+
+func TestLazyTrace(t *testing.T) {
+	t.Parallel()
+
+	x := 1
+	lazy := func() int {
+		return x
+	}
+
+	l, _, r := testLogger()
+	l.Trace("", "x", Lazy{lazy})
+	if r.Ctx[1] != 1 {
+		t.Fatalf("Lazy function not evaluated, got %v, expected %d", r.Ctx[1], 1)
+	}
+
+	x = 2
 	l.Trace("", "x", Lazy{lazy})
 	if r.Ctx[1] != 2 {
 		t.Fatalf("Lazy function not evaluated, got %v, expected %d", r.Ctx[1], 1)
@@ -70,7 +91,7 @@ func TestInvalidLazy(t *testing.T) {
 	l.Info("", "x", Lazy{func(x int) int { return x }})
 	validate()
 
-	l.Trace("", "x", Lazy{func() {}})
+	l.Info("", "x", Lazy{func() {}})
 	validate()
 }
 
@@ -115,6 +136,31 @@ func TestJson(t *testing.T) {
 	validate("lvl", "eror")
 }
 
+
+func TestJsonTrace(t *testing.T) {
+	t.Parallel()
+
+	l, buf := testFormatter(JsonFormat())
+	l.Trace("some message", "x", 1, "y", 3.2)
+
+	var v map[string]interface{}
+	decoder := json.NewDecoder(buf)
+	if err := decoder.Decode(&v); err != nil {
+		t.Fatalf("Error decoding JSON: %v", v)
+	}
+
+	validate := func(key string, expected interface{}) {
+		if v[key] != expected {
+			t.Fatalf("Got %v expected %v for %v", v[key], expected, key)
+		}
+	}
+
+	validate("msg", "some message")
+	validate("x", float64(1)) // all numbers are floats in JSON land
+	validate("y", 3.2)
+	validate("lvl", "trce")
+}
+
 func TestJSONMap(t *testing.T) {
 	m := map[string]interface{}{
 		"name":     "gopher",
@@ -123,7 +169,7 @@ func TestJSONMap(t *testing.T) {
 	}
 
 	l, buf := testFormatter(JsonFormat())
-	l.Trace("logging structs", "struct", m)
+	l.Error("logging structs", "struct", m)
 
 	var v map[string]interface{}
 	decoder := json.NewDecoder(buf)
@@ -260,11 +306,6 @@ func TestLvlFilterHandler(t *testing.T) {
 		t.Fatalf("Expected zero record, but got record with msg: %v", r.Msg)
 	}
 
-	l.Trace("trace'd")
-	if r.Msg != "" {
-		t.Fatalf("Got record msg %s expected %s", r.Msg, "")
-	}
-
 	l.Warn("warned")
 	if r.Msg != "warned" {
 		t.Fatalf("Got record msg %s expected %s", r.Msg, "warned")
@@ -274,7 +315,29 @@ func TestLvlFilterHandler(t *testing.T) {
 	if r.Msg != "error'd" {
 		t.Fatalf("Got record msg %s expected %s", r.Msg, "error'd")
 	}
+}
 
+func TestLvlFilterHandlerTrace(t *testing.T) {
+	t.Parallel()
+
+	l := New()
+	h, r := testHandler()
+	l.SetHandler(LvlFilterHandler(LvlWarn, h))
+	l.Trace("trace'd")
+
+	if r.Msg != "" {
+		t.Fatalf("Expected zero record, but got record with msg: %v", r.Msg)
+	}
+
+	l.Info("info'd")
+	if r.Msg != "" {
+		t.Fatalf("Got record msg %s expected %s", r.Msg, "")
+	}
+
+	l.Warn("warn'd")
+	if r.Msg != "warn'd" {
+		t.Fatalf("Got record msg %s expected %s", r.Msg, "warn'd")
+	}
 }
 
 func TestNetHandler(t *testing.T) {
@@ -349,20 +412,42 @@ func TestMatchFilterHandler(t *testing.T) {
 	}
 }
 
+func TestMatchFilterHandlerTrace(t *testing.T) {
+t.Parallel()
+
+	l, h, r := testLogger()
+	l.SetHandler(MatchFilterHandler("err", nil, h))
+
+	l.Trace("test", "foo", "bar")
+	if r.Msg != "" {
+	t.Fatalf("expected filter handler to discard msg")
+	}
+
+	l.Trace("test2", "err", "bad fd")
+	if r.Msg != "" {
+	t.Fatalf("expected filter handler to discard msg")
+	}
+
+	l.Trace("test3", "err", nil)
+	if r.Msg != "test3" {
+	t.Fatalf("expected filter handler to allow msg")
+	}
+}
+
 func TestMatchFilterBuiltin(t *testing.T) {
 	t.Parallel()
 
 	l, h, r := testLogger()
-	l.SetHandler(MatchFilterHandler("lvl", LvlTrace, h))
+	l.SetHandler(MatchFilterHandler("lvl", LvlError, h))
 	l.Info("does not pass")
 
 	if r.Msg != "" {
 		t.Fatalf("got info level record that should not have matched")
 	}
 
-	l.Trace("trace!")
-	if r.Msg != "trace!" {
-		t.Fatalf("did not get trace level record that should have matched")
+	l.Error("error!")
+	if r.Msg != "error!" {
+		t.Fatalf("did not get error level record that should have matched")
 	}
 
 	r.Msg = ""
@@ -400,13 +485,13 @@ func TestFailoverHandler(t *testing.T) {
 		StreamHandler(w, JsonFormat()),
 		h))
 
-	l.Trace("test ok")
+	l.Debug("test ok")
 	if r.Msg != "" {
 		t.Fatalf("expected no failover")
 	}
 
 	w.fail = true
-	l.Trace("test failover", "x", 1)
+	l.Debug("test failover", "x", 1)
 	if r.Msg != "test failover" {
 		t.Fatalf("expected failover")
 	}

--- a/logger.go
+++ b/logger.go
@@ -22,11 +22,14 @@ const (
 	LvlWarn
 	LvlInfo
 	LvlDebug
+	LvlTrace
 )
 
 // Returns the name of a Lvl
 func (l Lvl) String() string {
 	switch l {
+	case LvlTrace:
+		return "trce"
 	case LvlDebug:
 		return "dbug"
 	case LvlInfo:
@@ -46,6 +49,8 @@ func (l Lvl) String() string {
 // Useful for parsing command line args and configuration files.
 func LvlFromString(lvlString string) (Lvl, error) {
 	switch lvlString {
+	case "trace", "trce":
+		return LvlTrace, nil
 	case "debug", "dbug":
 		return LvlDebug, nil
 	case "info":
@@ -90,6 +95,7 @@ type Logger interface {
 	SetHandler(h Handler)
 
 	// Log a message at the given level with context key/value pairs
+	Trace(msg string, ctx ...interface{})
 	Debug(msg string, ctx ...interface{})
 	Info(msg string, ctx ...interface{})
 	Warn(msg string, ctx ...interface{})
@@ -129,6 +135,10 @@ func newContext(prefix []interface{}, suffix []interface{}) []interface{} {
 	n := copy(newCtx, prefix)
 	copy(newCtx[n:], normalizedSuffix)
 	return newCtx
+}
+
+func (l *logger) Trace(msg string, ctx ...interface{}) {
+	l.write(msg, LvlTrace, ctx)
 }
 
 func (l *logger) Debug(msg string, ctx ...interface{}) {

--- a/root.go
+++ b/root.go
@@ -42,6 +42,11 @@ func Root() Logger {
 // etc.) to keep the call depth the same for all paths to logger.write so
 // runtime.Caller(2) always refers to the call site in client code.
 
+// Trace is a convenient alias for Root().Trace
+func Trace(msg string, ctx ...interface{}){
+	root.write(msg, LvlTrace, ctx)
+}
+
 // Debug is a convenient alias for Root().Debug
 func Debug(msg string, ctx ...interface{}) {
 	root.write(msg, LvlDebug, ctx)

--- a/syslog.go
+++ b/syslog.go
@@ -38,6 +38,8 @@ func sharedSyslog(fmtr Format, sysWr *syslog.Writer, err error) (Handler, error)
 			syslogFn = sysWr.Info
 		case LvlDebug:
 			syslogFn = sysWr.Debug
+		case LvlTrace:
+			syslogFn = func(m string) error {return nil} // Since there's no syslog level for trace
 		}
 
 		s := strings.TrimSpace(string(fmtr.Format(r)))


### PR DESCRIPTION
- Went through the entire package and added support for a 'Trace' log level.
- Modified/added tests for the 'Trace' log level

Run tests using:
`go test -v`