### PR TITLE
Add /v2 to module path in go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ChainSafe/log15
+module github.com/ChainSafe/log15/v2
 
 require (
 	github.com/go-stack/stack v1.8.0


### PR DESCRIPTION
* Added /v2 to the module path so go mod recognizes the version when importing into other projects.

See [go mod documentation](https://github.com/golang/go/wiki/Modules#semantic-import-versioning) for more details.
