### PR TITLE
Revert "Add /v2 to module path in go mod"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ChainSafe/log15/v2
+module github.com/ChainSafe/log15
 
 require (
 	github.com/go-stack/stack v1.8.0


### PR DESCRIPTION
Reverts ChainSafe/log15#4

As discussed, we are resetting the version to v1, so we don't need v2 in the module path.

